### PR TITLE
Start with a custom json chain without init command

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -173,6 +173,7 @@ var (
 		utils.BeaconGenesisTimeFlag,
 		utils.BeaconCheckpointFlag,
 		utils.CollectWitnessFlag,
+		utils.CustomChainFlag,
 	}, utils.NetworkFlags, utils.DatabaseFlags)
 
 	builderApiFlags = []cli.Flag{


### PR DESCRIPTION
This PR adds a new flag `--chain <genesis.json>` to the `geth` command. If set, `geth` will load the genesis from the provided JSON file. With this PR, it is not necessary anymore to run `geth init` to start a chain for a custom network.