### PR TITLE
Isolate extra data modification to builder module

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -374,6 +374,8 @@ func (b *Builder) handlePayloadAttributes(attrs *builderTypes.PayloadAttributes)
 		b.slotCtxCancel()
 	}
 
+	attrs.ExtraData = b.extraData
+
 	slotCtx, slotCtxCancel := context.WithTimeout(context.Background(), b.builderBlockTime)
 	b.slotAttrs = *attrs
 	b.slotCtx = slotCtx

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -61,6 +61,8 @@ type Builder struct {
 	bestBlockMu sync.Mutex
 	bestBlock   *builderTypes.VersionedBuilderPayloadResponse
 
+	extraData []byte
+
 	stop chan struct{}
 }
 
@@ -74,6 +76,7 @@ type BuilderArgs struct {
 	eth                         IEthereumService
 	ignoreLatePayloadAttributes bool
 	beaconClient                IBeaconClient
+	extraData                   []byte
 }
 
 // SubmitBlockOpts is a struct that contains all the arguments needed to submit a block to the relay
@@ -100,6 +103,8 @@ func NewBuilder(args BuilderArgs) (*Builder, error) {
 
 		slotCtx:       slotCtx,
 		slotCtxCancel: slotCtxCancel,
+
+		extraData: args.extraData,
 
 		stop: make(chan struct{}, 1),
 	}, nil

--- a/builder/config.go
+++ b/builder/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	RetryInterval               string        `toml:",omitempty"`
 	BlockTime                   time.Duration `toml:",omitempty"`
 	ProposerAddress             string        `toml:",omitempty"`
+	ExtraData                   string        `toml:",omitempty"`
 }
 
 // DefaultConfig is the default config for the builder.
@@ -29,4 +30,5 @@ var DefaultConfig = Config{
 	BeaconEndpoints:             []string{"http://127.0.0.1:5052"},
 	RetryInterval:               RetryIntervalDefault.String(),
 	BlockTime:                   BlockTimeDefault,
+	ExtraData:                   "",
 }

--- a/builder/eth_service.go
+++ b/builder/eth_service.go
@@ -46,10 +46,9 @@ func (s *EthereumService) BuildBlock(attrs *builderTypes.PayloadAttributes) (*en
 		BeaconRoot:   attrs.ParentBeaconBlockRoot,
 		Transactions: attrs.Transactions,
 		NoTxPool:     attrs.NoTxPool,
-		ExtraData:    attrs.ExtraData,
 	}
 
-	payload, err := s.eth.Miner().BuildPayload(args)
+	payload, err := s.eth.Miner().BuildPayloadWithExtraData(args, attrs.ExtraData)
 	if err != nil {
 		log.Error("Failed to build payload", "err", err)
 		return nil, err

--- a/builder/eth_service.go
+++ b/builder/eth_service.go
@@ -46,6 +46,7 @@ func (s *EthereumService) BuildBlock(attrs *builderTypes.PayloadAttributes) (*en
 		BeaconRoot:   attrs.ParentBeaconBlockRoot,
 		Transactions: attrs.Transactions,
 		NoTxPool:     attrs.NoTxPool,
+		ExtraData:    attrs.ExtraData,
 	}
 
 	payload, err := s.eth.Miner().BuildPayload(args)

--- a/builder/service.go
+++ b/builder/service.go
@@ -113,6 +113,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 		ignoreLatePayloadAttributes: cfg.IgnoreLatePayloadAttributes,
 		beaconClient:                beaconClient,
 		blockTime:                   cfg.BlockTime,
+		extraData:                   []byte(cfg.ExtraData),
 	}
 
 	builderBackend, err := NewBuilder(builderArgs)

--- a/builder/types/attributes.go
+++ b/builder/types/attributes.go
@@ -19,6 +19,8 @@ type PayloadAttributes struct {
 
 	NoTxPool     bool                 `json:"noTxPool,omitempty"` // Optimism addition: option to disable tx pool contents from being included
 	Transactions []*types.Transaction `json:"transactions"`       // Optimism addition: txs forced into the block via engine API
+
+	ExtraData []byte `json:"extraData,omitempty"` // Flashbots addition: extra data to include in the block
 }
 
 func (attrs *PayloadAttributes) Equal(other *PayloadAttributes) bool {
@@ -38,6 +40,10 @@ func (attrs *PayloadAttributes) Equal(other *PayloadAttributes) bool {
 	}
 
 	if !slices.Equal(attrs.Transactions, other.Transactions) {
+		return false
+	}
+
+	if !slices.Equal(attrs.ExtraData, other.ExtraData) {
 		return false
 	}
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -185,6 +185,7 @@ var (
 		utils.BuilderBlockRetryInterval,
 		utils.BuilderBlockTime,
 		utils.BuilderProposerSigningAddress,
+		utils.BuilderExtraData,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -724,6 +724,12 @@ var (
 		EnvVars:  []string{"BUILDER_PROPOSER_SIGNING_ADDRESS"},
 		Category: flags.BuilderCategory,
 	}
+	BuilderExtraData = &cli.StringFlag{
+		Name:     "builder.extra_data",
+		Usage:    "Extra data to include in the block",
+		EnvVars:  []string{"BUILDER_EXTRA_DATA"},
+		Category: flags.BuilderCategory,
+	}
 
 	CustomChainFlag = &cli.StringFlag{
 		Name:     "chain",
@@ -1589,6 +1595,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	cfg.RetryInterval = ctx.String(BuilderBlockRetryInterval.Name)
 	cfg.BlockTime = ctx.Duration(BuilderBlockTime.Name)
 	cfg.ProposerAddress = ctx.String(BuilderProposerSigningAddress.Name)
+	cfg.ExtraData = ctx.String(BuilderExtraData.Name)
 }
 
 // SetNodeConfig applies node-related command line flags to the config.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -152,7 +152,12 @@ func (miner *Miner) SetGasTip(tip *big.Int) error {
 
 // BuildPayload builds the payload according to the provided parameters.
 func (miner *Miner) BuildPayload(args *BuildPayloadArgs) (*Payload, error) {
-	return miner.buildPayload(args)
+	return miner.buildPayload(args, nil)
+}
+
+// BuildPayloadWithExtraData builds the payload according to the provided parameters and extra data.
+func (miner *Miner) BuildPayloadWithExtraData(args *BuildPayloadArgs, extra []byte) (*Payload, error) {
+	return miner.buildPayload(args, extra)
 }
 
 // getPending retrieves the pending block based on the current head block.

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -47,8 +47,6 @@ type BuildPayloadArgs struct {
 	NoTxPool     bool                 // Optimism addition: option to disable tx pool contents from being included
 	Transactions []*types.Transaction // Optimism addition: txs forced into the block via engine API
 	GasLimit     *uint64              // Optimism addition: override gas limit of the block to build
-
-	ExtraData []byte // Flashbots addition: extra data to include in the block
 }
 
 // Id computes an 8-byte identifier by hashing the components of the payload arguments.
@@ -246,7 +244,7 @@ func (payload *Payload) stopBuilding() {
 }
 
 // buildPayload builds the payload according to the provided parameters.
-func (miner *Miner) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
+func (miner *Miner) buildPayload(args *BuildPayloadArgs, extraData []byte) (*Payload, error) {
 	if args.NoTxPool { // don't start the background payload updating job if there is no tx pool to pull from
 		// Build the initial version with no transaction included. It should be fast
 		// enough to run. The empty payload can at least make sure there is something
@@ -263,7 +261,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 			noTxs:       true,
 			txs:         args.Transactions,
 			gasLimit:    args.GasLimit,
-			extraData:   args.ExtraData,
+			extraData:   extraData,
 		}
 		empty := miner.generateWork(emptyParams)
 		if empty.err != nil {
@@ -288,7 +286,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 		noTxs:       false,
 		txs:         args.Transactions,
 		gasLimit:    args.GasLimit,
-		extraData:   args.ExtraData,
+		extraData:   extraData,
 	}
 
 	// Since we skip building the empty block when using the tx pool, we need to explicitly

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -47,6 +47,8 @@ type BuildPayloadArgs struct {
 	NoTxPool     bool                 // Optimism addition: option to disable tx pool contents from being included
 	Transactions []*types.Transaction // Optimism addition: txs forced into the block via engine API
 	GasLimit     *uint64              // Optimism addition: override gas limit of the block to build
+
+	ExtraData []byte // Flashbots addition: extra data to include in the block
 }
 
 // Id computes an 8-byte identifier by hashing the components of the payload arguments.
@@ -261,6 +263,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 			noTxs:       true,
 			txs:         args.Transactions,
 			gasLimit:    args.GasLimit,
+			extraData:   args.ExtraData,
 		}
 		empty := miner.generateWork(emptyParams)
 		if empty.err != nil {
@@ -285,6 +288,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 		noTxs:       false,
 		txs:         args.Transactions,
 		gasLimit:    args.GasLimit,
+		extraData:   args.ExtraData,
 	}
 
 	// Since we skip building the empty block when using the tx pool, we need to explicitly

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -101,6 +101,8 @@ type generateParams struct {
 	gasLimit  *uint64            // Optional gas limit override
 	interrupt *atomic.Int32      // Optional interruption signal to pass down to worker.generateWork
 	isUpdate  bool               // Optional flag indicating that this is building a discardable update
+
+	extraData []byte // Extra data to include in the block
 }
 
 // generateWork generates a sealing block based on the given parameters.
@@ -197,9 +199,10 @@ func (miner *Miner) prepareWork(genParams *generateParams) (*environment, error)
 		Time:       timestamp,
 		Coinbase:   genParams.coinbase,
 	}
-	// Set the extra field.
-	if len(miner.config.ExtraData) != 0 && miner.chainConfig.Optimism == nil { // Optimism chains must not set any extra data.
-		header.Extra = miner.config.ExtraData
+	// Set the extra field if specified.
+	if len(genParams.extraData) != 0 {
+		log.Debug("Setting extra data", "extraData", genParams.extraData)
+		header.Extra = genParams.extraData
 	}
 	// Set the randomness field from the beacon chain if it's available.
 	if genParams.random != (common.Hash{}) {


### PR DESCRIPTION
The extra data set by miner configuration should only be set when builder is building payloads to serve.

op-node deriver forces forkchoiceUpdate when [pendingSafeL2Head.Number == unsafeL2Head.Number](https://github.com/flashbots/optimism/blob/20c313771ce95019bae1d01b66c2b26a23e1bb25/op-node/rollup/attributes/attributes.go#L94), which causes op-geth to build block with different extra data than it was supposed to, forking the chain. 

More investigation is needed when above condition happens. This bug was found when starting the chain from fresh on the devnet, and the op-node seems to force insert some early blocks after genesis block. 

This PR is to isolate the extra data modification to the builder module only. 